### PR TITLE
[#9] feat: 회원 탈퇴

### DIFF
--- a/src/main/java/dabang/star/cafe/api/CurrentMemberApi.java
+++ b/src/main/java/dabang/star/cafe/api/CurrentMemberApi.java
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.servlet.http.HttpSession;
 
 @RequiredArgsConstructor
-@RestController("/member")
-public class MemberInfoApi {
+@RestController("/my-infos")
+public class CurrentMemberApi {
 
     private final MemberService memberService;
     private final LoginService loginService;
 
     /**
-     * 멤버 회원탈퇴
+     * 멤버 삭제
      */
     @MemberLoginCheck
     @DeleteMapping

--- a/src/main/java/dabang/star/cafe/api/MemberApi.java
+++ b/src/main/java/dabang/star/cafe/api/MemberApi.java
@@ -8,7 +8,6 @@ import dabang.star.cafe.api.response.member.MemberData;
 import dabang.star.cafe.domain.login.LoginService;
 import dabang.star.cafe.domain.member.Member;
 import dabang.star.cafe.domain.member.MemberService;
-import dabang.star.cafe.utils.ResponseStatus;
 import dabang.star.cafe.utils.SessionKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,7 +19,7 @@ import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/members")
+@RequestMapping("/member")
 public class MemberApi {
 
     private final MemberService memberService;
@@ -56,15 +55,11 @@ public class MemberApi {
 
     /**
      * 로그아웃
-     *
-     * @return 로그아웃 완료시 HttpsStatus.OK, 반환
      */
     @PostMapping("/logout")
-    public ResponseEntity logoutMember() {
+    public void logoutMember() {
 
         loginService.logout();
-
-        return ResponseStatus.OK;
     }
 
 
@@ -86,21 +81,5 @@ public class MemberApi {
         MemberData memberData = memberService.findById(id);
         return ResponseEntity.status(HttpStatus.OK).body(memberData);
     }
-
-    /**
-     * 멤버 회원탈퇴
-     *
-     * @return 회원탈퇴 완료시 로그아웃 후 HttpsStatus.OK, 반환
-     */
-    @MemberLoginCheck
-    @DeleteMapping("/info")
-    public ResponseEntity deleteMember(HttpSession httpSession) {
-
-        Long id = (Long) httpSession.getAttribute(SessionKey.LOGIN_MEMBER_ID);
-        memberService.secession(id);
-
-        loginService.logout();
-
-        return ResponseStatus.OK;
-    }
+    
 }

--- a/src/main/java/dabang/star/cafe/api/MemberApi.java
+++ b/src/main/java/dabang/star/cafe/api/MemberApi.java
@@ -70,8 +70,9 @@ public class MemberApi {
 
     /**
      * 멤버 업데이트
+     *
      * @param memberUpdateRequest (password, nickname, telephone)
-     * @param httpSession (httpSession)
+     * @param httpSession         (httpSession)
      * @return 업데이트 완료시 HttpStatus.OK 반환
      */
     @MemberLoginCheck
@@ -84,5 +85,22 @@ public class MemberApi {
 
         MemberData memberData = memberService.findById(id);
         return ResponseEntity.status(HttpStatus.OK).body(memberData);
+    }
+
+    /**
+     * 멤버 회원탈퇴
+     *
+     * @return 회원탈퇴 완료시 로그아웃 후 HttpsStatus.OK, 반환
+     */
+    @MemberLoginCheck
+    @DeleteMapping("/info")
+    public ResponseEntity deleteMember(HttpSession httpSession) {
+
+        Long id = (Long) httpSession.getAttribute(SessionKey.LOGIN_MEMBER_ID);
+        memberService.secession(id);
+
+        loginService.logout();
+
+        return ResponseStatus.OK;
     }
 }

--- a/src/main/java/dabang/star/cafe/api/MemberInfoApi.java
+++ b/src/main/java/dabang/star/cafe/api/MemberInfoApi.java
@@ -1,0 +1,33 @@
+package dabang.star.cafe.api;
+
+import dabang.star.cafe.api.aop.MemberLoginCheck;
+import dabang.star.cafe.domain.login.LoginService;
+import dabang.star.cafe.domain.member.MemberService;
+import dabang.star.cafe.utils.SessionKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@RestController("/member")
+public class MemberInfoApi {
+
+    private final MemberService memberService;
+    private final LoginService loginService;
+
+    /**
+     * 멤버 회원탈퇴
+     */
+    @MemberLoginCheck
+    @DeleteMapping
+    public void deleteMember(HttpSession httpSession) {
+
+        Long id = (Long) httpSession.getAttribute(SessionKey.LOGIN_MEMBER_ID);
+        memberService.secession(id);
+
+        loginService.logout();
+    }
+
+}

--- a/src/main/java/dabang/star/cafe/domain/member/MemberRepository.java
+++ b/src/main/java/dabang/star/cafe/domain/member/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository {
     Optional<MemberData> findMemberByEmailAndPassword(String email, String password);
 
     Optional<MemberData> findMemberById(Long email);
+
+    void delete(Long id);
 }

--- a/src/main/java/dabang/star/cafe/domain/member/MemberService.java
+++ b/src/main/java/dabang/star/cafe/domain/member/MemberService.java
@@ -11,4 +11,6 @@ public interface MemberService {
     void update(Member member);
 
     MemberData findById(Long id);
+
+    public void secession(Long id);
 }

--- a/src/main/java/dabang/star/cafe/domain/member/MemberService.java
+++ b/src/main/java/dabang/star/cafe/domain/member/MemberService.java
@@ -12,5 +12,5 @@ public interface MemberService {
 
     MemberData findById(Long id);
 
-    public void secession(Long id);
+    void secession(Long id);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/mapper/MemberMapper.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/mapper/MemberMapper.java
@@ -19,4 +19,6 @@ public interface MemberMapper {
     Optional<MemberData> getByEmailAndPassword(@Param("email") String email, @Param("password") String password);
 
     Optional<MemberData> findById(@Param("id") Long id);
+
+    void deleteById(@Param("id") Long id);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepository.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepository.java
@@ -41,6 +41,13 @@ public class MybatisMemberRepository implements MemberRepository {
 
     @Override
     public Optional<MemberData> findMemberById(Long id) {
+
         return memberMapper.findById(id);
+    }
+
+    @Override
+    public void delete(Long id) {
+
+        memberMapper.deleteById(id);
     }
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/service/MemberServiceImpl.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/service/MemberServiceImpl.java
@@ -50,4 +50,9 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new MemberNotFoundException("member not found"));
     }
 
+    @Override
+    public void secession(Long id) {
+
+        memberRepository.delete(id);
+    }
 }

--- a/src/main/resources/mybatis-mapper/MemberMapper.xml
+++ b/src/main/resources/mybatis-mapper/MemberMapper.xml
@@ -34,4 +34,10 @@
         WHERE m.member_id = #{id}
     </select>
 
+    <delete id="deleteById">
+        DELETE
+        FROM members
+        WHERE member_id = #{id}
+    </delete>
+
 </mapper>

--- a/src/test/java/dabang/star/cafe/api/MemberApiTest.java
+++ b/src/test/java/dabang/star/cafe/api/MemberApiTest.java
@@ -3,7 +3,6 @@ package dabang.star.cafe.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dabang.star.cafe.api.request.SignUpRequest;
 import dabang.star.cafe.api.response.ErrorResponse;
-import dabang.star.cafe.api.response.member.MemberData;
 import dabang.star.cafe.domain.member.Member;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.*;

--- a/src/test/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepositoryTest.java
+++ b/src/test/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepositoryTest.java
@@ -65,4 +65,15 @@ class MybatisMemberRepositoryTest {
         assertThat(result).isFalse();
     }
 
+    @DisplayName("회원을 삭제할 수 있어야 한다")
+    @Test
+    void deleteMemberTest() {
+        memberRepository.save(member);
+        memberRepository.delete(member.getId());
+
+        Optional<MemberData> findMember = memberRepository.findMemberById(member.getId());
+
+        assertThat(findMember).isEmpty();
+    }
+
 }

--- a/src/test/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepositoryTest.java
+++ b/src/test/java/dabang/star/cafe/infrastructure/repository/MybatisMemberRepositoryTest.java
@@ -65,7 +65,7 @@ class MybatisMemberRepositoryTest {
         assertThat(result).isFalse();
     }
 
-    @DisplayName("회원을 삭제할 수 있어야 한다")
+    @DisplayName("회원의 id가 주어졌을 때 회원을 삭제한다")
     @Test
     void deleteMemberTest() {
         memberRepository.save(member);


### PR DESCRIPTION
feature/10과 공통되는 로직이 많이 존재하여 인가관련 부분을 위해 브랜치를 feature/10에서 따서 작업하였습니다.

URL 협의
* 회원정보 조회(패스워드 인증) -> 정보 변경 후 저장 또는 탈퇴 
* members/info

게임이나 SNS같이 계정을 복구할 필요성이 없어 보여 회원 삭제 조치