### PR TITLE
[#40] AWS S3 상에 업로드하는 서비스 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+aws.yaml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,13 @@ dependencies {
     // 스프링 부트 2.3부터 spring-boot-starter-web 에서 제외된 validation 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // AWS 관련 의존성 추가 (S3 관련 Bean 자동 생성)
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // JDK 9+ SE 에서 제외된 JAXB 의존성 추가 (URL 참고)
+    // https://github.com/aws/aws-sdk-java/blob/6a086cfd3e26f74592cf3a7cb96f43e51654a926/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java#L67
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
     // MySQL 의존성 추가
     runtimeOnly 'mysql:mysql-connector-java'
 

--- a/src/main/java/dabang/star/cafe/CafeApplication.java
+++ b/src/main/java/dabang/star/cafe/CafeApplication.java
@@ -1,22 +1,15 @@
 package dabang.star.cafe;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-
-import java.util.Map;
 
 @EnableAspectJAutoProxy
 @SpringBootApplication
 public class CafeApplication {
 
-    private static final String SPRING_CONFIG_LOCATION = "spring.config.location";
-    private static final String YAMLS = "classpath:/application.yaml,classpath:/aws.yaml";
-
     public static void main(String[] args) {
-        new SpringApplicationBuilder(CafeApplication.class)
-                .properties(Map.of(SPRING_CONFIG_LOCATION, YAMLS))
-                .run(args);
+        SpringApplication.run(CafeApplication.class, args);
     }
 
 }

--- a/src/main/java/dabang/star/cafe/CafeApplication.java
+++ b/src/main/java/dabang/star/cafe/CafeApplication.java
@@ -1,15 +1,22 @@
 package dabang.star.cafe;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import java.util.Map;
 
 @EnableAspectJAutoProxy
 @SpringBootApplication
 public class CafeApplication {
 
+    private static final String SPRING_CONFIG_LOCATION = "spring.config.location";
+    private static final String YAMLS = "classpath:/application.yaml,classpath:/aws.yaml";
+
     public static void main(String[] args) {
-        SpringApplication.run(CafeApplication.class, args);
+        new SpringApplicationBuilder(CafeApplication.class)
+                .properties(Map.of(SPRING_CONFIG_LOCATION, YAMLS))
+                .run(args);
     }
 
 }

--- a/src/main/java/dabang/star/cafe/domain/service/UploadService.java
+++ b/src/main/java/dabang/star/cafe/domain/service/UploadService.java
@@ -1,0 +1,10 @@
+package dabang.star.cafe.domain.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface UploadService {
+
+    String upload(MultipartFile multipartFile, String dirPrefix) throws IOException;
+}

--- a/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
@@ -42,7 +42,7 @@ public class S3UploadService implements UploadService {
                 .withCannedAcl(CannedAccessControlList.PublicRead)
         );
 
-        log.info(uploadFile.delete() ? "파일이 삭제되었습니다." : "파일이 삭제되지 않았습니다.");
+        log.debug(uploadFile.delete() ? "파일이 삭제되었습니다." : "파일이 삭제되지 않았습니다.");
 
         return s3Client.getUrl(bucket, fileName).toString();
     }

--- a/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
@@ -1,0 +1,62 @@
+package dabang.star.cafe.infrastructure.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import dabang.star.cafe.domain.service.UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3UploadService implements UploadService {
+
+    private final AmazonS3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 1. MultipartFile을 전달 받아 File로 전환.
+     * 2. S3에 Public 읽기 권한으로 업로드하고 로컬에 생성된 파일 삭제 후 S3 객체 URL 반환.
+     */
+    public String upload(MultipartFile multipartFile, String dirPrefix) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("파일 변환에 실패하였습니다."));
+        String fileName = dirPrefix + "/" + uploadFile.getName();
+
+        return putS3(uploadFile, fileName);
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        s3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+
+        log.info(uploadFile.delete() ? "파일이 삭제되었습니다." : "파일이 삭제되지 않았습니다.");
+
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private Optional<File> convert(MultipartFile multipartFile) throws IOException {
+        File convertFile = new File(multipartFile.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(convertFile)) {
+                fileOutputStream.write(multipartFile.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,11 +42,17 @@ spring:
   config:
     activate:
       on-profile: test
+    import: optional:aws.yaml
 
   session:
     store-type: redis
     redis:
       namespace: star_dabang:session
+
+cloud:
+  aws:
+    s3:
+      bucket: star-dabang
 
 
 mybatis:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ spring:
   config:
     activate:
       on-profile: dev
+    import: optional:aws.yaml
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -21,6 +22,11 @@ spring:
     store-type: redis
     redis:
       namespace: star_dabang:session
+
+cloud:
+  aws:
+    s3:
+      bucket: star-dabang
 
   redis:
     host: localhost


### PR DESCRIPTION
보안을 위해 aws.yaml 파일을 따로 만들고 gitignore 설정하였습니다.
yaml 파일에 포함된 해당 credentials 를 가진 aws 사용자에 AmazonS3FullAccess 정책을 주었고
만든 버킷은 퍼블릭 차단을 비활성화 하였습니다.

MultipartFile을 받는 간단한 API인 다음 코드(커밋X)를 작성 후
포스트맨 활용한 테스트를 통해 정상적으로 S3 상에 업로드 됨을 확인하였습니다.

```java
package dabang.star.cafe.api;

import dabang.star.cafe.api.aop.LoginCheck;
import dabang.star.cafe.domain.manager.Role;
import dabang.star.cafe.domain.service.UploadService;
import lombok.RequiredArgsConstructor;
import org.springframework.web.bind.annotation.*;
import org.springframework.web.multipart.MultipartFile;

import java.io.IOException;

@RestController
@RequiredArgsConstructor
@RequestMapping("/products/images")
public class ProductImageAdminApi {

    private static final String PRODUCT = "product";
    private final UploadService uploadService;

    @LoginCheck(role = Role.ADMIN)
    @PostMapping
    public String upload(@RequestPart MultipartFile file) throws IOException {
        return uploadService.upload(file, PRODUCT);
    }

}

```