### PR TITLE
[#44] 로거를 Log4j2 사용하도록 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
+    all {
+        // 스프링 부트 기본 로거인 logback 대신 lo4j2 를 사용하기 위해 제외한다.
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -32,6 +37,13 @@ dependencies {
 
     // 스프링 부트 2.3부터 spring-boot-starter-web 에서 제외된 validation 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // logback 보다 처리량이 뛰어난 log4j2 의존성 추가
+    // https://logging.apache.org/log4j/2.x/performance.html
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
+    // lo4j2 설정 파일을 yaml 파일로 작성하기 위한 의존성 추가 (설정 파일 형식은 XML, JSON, YAML, Properties 로 작성 가능)
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
     // AWS 관련 의존성 추가 (S3 관련 Bean 자동 생성)
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/dabang/star/cafe/api/CustomExceptionHandler.java
+++ b/src/main/java/dabang/star/cafe/api/CustomExceptionHandler.java
@@ -6,14 +6,14 @@ import dabang.star.cafe.application.exception.NoAuthorizationException;
 import dabang.star.cafe.application.exception.ResourceNotFoundException;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j
+@Log4j2
 @RestControllerAdvice
 public class CustomExceptionHandler {
 

--- a/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/service/S3UploadService.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import dabang.star.cafe.domain.service.UploadService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,7 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Optional;
 
-@Slf4j
+@Log4j2
 @RequiredArgsConstructor
 @Component
 public class S3UploadService implements UploadService {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,9 @@ mybatis:
   mapper-locations: classpath:mybatis-mapper/**/*.xml
   type-aliases-package: dabang.star.cafe.domain, dabang.star.cafe.application.data
 
+logging:
+  config: classpath:log4j2.yaml
+
 ---
 spring:
   config:

--- a/src/main/resources/log4j2.yaml
+++ b/src/main/resources/log4j2.yaml
@@ -1,0 +1,21 @@
+Configutation:
+  name: Default
+  status: warn
+
+  Appenders:
+    Console:
+      name: Console_Appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: Console_Appender
+    Logger:
+      - name: dabang.star
+        additivity: false
+        level: debug
+        AppenderRef:
+          - ref: Console_Appender


### PR DESCRIPTION
스프링 부트의 기본 로거인 logback보다 성능이 뛰어난 log4j2를 적용하였습니다.
(https://logging.apache.org/log4j/2.x/performance.html)

log4j2 설정파일로 가독성이 좋은 yaml파일을 사용하기 위해 jackson-dataformat-yaml 의존성 추가하였습니다.

Log4j2는 Slf4j의 API를 모두 제공하기 때문에 Slf4j 어댑터를 사용하여도 되지만 약간의 성능 하락이 있을 수 있다고 하여 직접 Log4j2사용하도록 롬복 어노테이션 설정하였습니다. (https://logging.apache.org/log4j/2.x/log4j-to-slf4j/index.html)