### PR TITLE
[#51] DB 스키마 수정 및 리팩토링

### DIFF
--- a/src/main/java/dabang/star/cafe/application/command/CategoryCreateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/CategoryCreateCommand.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,6 +16,7 @@ import javax.validation.constraints.NotNull;
 public class CategoryCreateCommand {
 
     @NotNull(message = "invalid name")
+    @Size(max = 20, message = "invalid name")
     private String name;
 
     @NotNull(message = "invalid category type")

--- a/src/main/java/dabang/star/cafe/application/command/CategoryUpdateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/CategoryUpdateCommand.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,6 +19,7 @@ public class CategoryUpdateCommand {
     private Integer id;
 
     @NotNull(message = "invalid name")
+    @Size(max = 20, message = "invalid name")
     private String name;
 
     @NotNull(message = "invalid category name")

--- a/src/main/java/dabang/star/cafe/application/command/ManagerCreateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/ManagerCreateCommand.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,6 +16,7 @@ import javax.validation.constraints.NotBlank;
 public class ManagerCreateCommand {
 
     @NotBlank(message = "invalid name")
+    @Size(max = 20, message = "invalid name")
     private String name;
 
     @NotBlank(message = "invalid password")

--- a/src/main/java/dabang/star/cafe/application/command/OfficeUpdateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OfficeUpdateCommand.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.math.BigDecimal;
 
 @Getter
@@ -19,6 +20,7 @@ public class OfficeUpdateCommand {
     private Integer id;
 
     @NotBlank(message = "blank office name")
+    @Size(max = 50, message = "invalid office name")
     private String name;
 
     @NotBlank(message = "blank office address")

--- a/src/main/java/dabang/star/cafe/application/command/OptionCreateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OptionCreateCommand.java
@@ -6,24 +6,25 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class OptionCreateCommand {
 
-    @NotNull(message = "blank name")
+    @NotBlank(message = "blank name")
+    @Size(max = 10, message = "not valid name")
     private String name;
 
     @NotNull(message = "blank price")
     @PositiveOrZero(message = "not valid price")
+    @Max(value = 65535)
     private Integer price;
 
     @NotNull(message = "blank max quantity")
     @Positive(message = "not valid max quantity")
+    @Max(value = 255)
     private Integer maxQuantity;
 
     public Option toOption() {
@@ -34,5 +35,5 @@ public class OptionCreateCommand {
                 .maxQuantity(maxQuantity)
                 .build();
     }
-    
+
 }

--- a/src/main/java/dabang/star/cafe/application/command/OptionUpdateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OptionUpdateCommand.java
@@ -6,9 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,17 +14,20 @@ import javax.validation.constraints.PositiveOrZero;
 public class OptionUpdateCommand {
 
     @NotNull(message = "blank option id")
-    private Integer id;
+    private Long id;
 
-    @NotNull(message = "blank option name")
+    @NotBlank(message = "blank option name")
+    @Size(max = 10, message = "not valid name")
     private String name;
 
     @NotNull(message = "blank option price")
     @PositiveOrZero(message = "not valid option price")
+    @Max(value = 65535)
     private Integer price;
 
     @NotNull(message = "blank option max quantity")
     @Positive(message = "not valid option max quantity")
+    @Max(value = 255)
     private Integer maxQuantity;
 
     public Option toOption() {

--- a/src/main/java/dabang/star/cafe/domain/option/Option.java
+++ b/src/main/java/dabang/star/cafe/domain/option/Option.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Option {
 
-    private Integer id;
+    private Long id;
 
     private String name;
 

--- a/src/main/java/dabang/star/cafe/domain/option/OptionRepository.java
+++ b/src/main/java/dabang/star/cafe/domain/option/OptionRepository.java
@@ -14,8 +14,9 @@ public interface OptionRepository {
 
     List<Option> findByName(String optionName);
 
-    Optional<Option> findById(int id);
+    Optional<Option> findById(long id);
 
-    int deleteById(int id);
+    int deleteById(long id);
 
+    boolean existsById(long id);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/mapper/OptionMapper.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/mapper/OptionMapper.java
@@ -20,8 +20,9 @@ public interface OptionMapper {
 
     List<Option> selectByName(String name);
 
-    Optional<Option> getById(@Param("id") int id);
+    Optional<Option> getById(@Param("id") long id);
 
-    int removeById(@Param("id") int id);
+    int removeById(@Param("id") long id);
 
+    boolean containsKey(@Param("id") long id);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOptionRepository.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOptionRepository.java
@@ -46,15 +46,19 @@ public class MybatisOptionRepository implements OptionRepository {
     }
 
     @Override
-    public Optional<Option> findById(int id) {
+    public Optional<Option> findById(long id) {
 
         return optionMapper.getById(id);
     }
 
     @Override
-    public int deleteById(int id) {
+    public int deleteById(long id) {
 
         return optionMapper.removeById(id);
     }
 
+    @Override
+    public boolean existsById(long id) {
+        return optionMapper.containsKey(id);
+    }
 }

--- a/src/main/resources/data-dev.sql
+++ b/src/main/resources/data-dev.sql
@@ -1,12 +1,12 @@
-INSERT INTO members(email, passwd, nickName, phone, birth)
+INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test1@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
-INSERT INTO members(email, passwd, nickName, phone, birth)
+INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test2@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
-INSERT INTO members(email, passwd, nickName, phone, birth)
+INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test3@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
-INSERT INTO members(email, passwd, nickName, phone, birth)
+INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test4@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
-INSERT INTO members(email, passwd, nickName, phone, birth)
+INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test5@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
 
 INSERT INTO office(office_name, address, latitude, longitude)

--- a/src/main/resources/mybatis-mapper/MemberMapper.xml
+++ b/src/main/resources/mybatis-mapper/MemberMapper.xml
@@ -3,12 +3,12 @@
 <mapper namespace="dabang.star.cafe.infrastructure.mapper.MemberMapper">
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO members (email, passwd, nickname, phone, birth)
+        INSERT INTO member (email, passwd, nickname, phone, birth)
         VALUES (#{email}, #{password}, #{nickname}, #{telephone}, #{birth})
     </insert>
 
     <update id="update" keyProperty="id">
-        UPDATE members
+        UPDATE member
         <set>
             <if test="password != null">passwd=#{password},</if>
             <if test="nickname != null">nickname=#{nickname},</if>
@@ -18,32 +18,32 @@
     </update>
 
     <select id="exists" resultType="boolean">
-        SELECT EXISTS(SELECT m.member_id FROM members m WHERE m.email = #{email})
+        SELECT EXISTS(SELECT m.member_id FROM member m WHERE m.email = #{email})
     </select>
 
     <select id="getByEmailAndPassword" resultType="MemberData" parameterType="map">
         SELECT m.member_id, m.email, m.nickname
-        FROM members m
+        FROM member m
         WHERE m.email = #{email}
           AND m.passwd = #{password}
     </select>
 
     <select id="getById" resultType="MemberData" parameterType="map">
         SELECT m.member_id, m.email, m.nickname
-        FROM members m
+        FROM member m
         WHERE m.member_id = #{id}
     </select>
 
     <select id="getByIdAndPassword" resultType="MemberData" parameterType="map">
         SELECT m.member_id, m.email, m.nickname
-        FROM members m
+        FROM member m
         WHERE m.member_id = #{id}
           AND m.passwd = #{password}
     </select>
 
     <delete id="removeById">
         DELETE
-        FROM members
+        FROM member
         WHERE member_id = #{id}
     </delete>
 

--- a/src/main/resources/mybatis-mapper/OptionMapper.xml
+++ b/src/main/resources/mybatis-mapper/OptionMapper.xml
@@ -59,4 +59,8 @@
         WHERE option_id = #{id}
     </delete>
 
+    <select id="containsKey" resultType="boolean">
+        SELECT EXISTS(SELECT o.option_id FROM additional_option o WHERE o.option_id = #{id})
+    </select>
+
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,15 +1,14 @@
 DROP TABLE IF EXISTS my_menu;
 DROP TABLE IF EXISTS office_stock;
-DROP TABLE IF EXISTS product;
 DROP TABLE IF EXISTS product_option;
+DROP TABLE IF EXISTS product;
 DROP TABLE IF EXISTS additional_option;
 DROP TABLE IF EXISTS product_category;
-DROP TABLE IF EXISTS product_type;
 DROP TABLE IF EXISTS manager;
 DROP TABLE IF EXISTS office;
-DROP TABLE IF EXISTS members;
+DROP TABLE IF EXISTS member;
 
-CREATE TABLE members
+CREATE TABLE member
 (
     member_id BIGINT       NOT NULL AUTO_INCREMENT,
     passwd    VARCHAR(255) NOT NULL,
@@ -24,7 +23,7 @@ CREATE TABLE members
 
 CREATE TABLE office
 (
-    office_id   INT             NOT NULL AUTO_INCREMENT,
+    office_id   MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
     office_name VARCHAR(50)     NOT NULL,
     address     VARCHAR(255)    NOT NULL,
     latitude    DECIMAL(16, 14) NOT NULL,
@@ -35,8 +34,8 @@ CREATE TABLE office
 
 CREATE TABLE manager
 (
-    manager_id BIGINT       NOT NULL AUTO_INCREMENT,
-    office_id  INT          NOT NULL,
+    manager_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    office_id  MEDIUMINT UNSIGNED NOT NULL,
     name       VARCHAR(20)  NOT NULL,
     passwd     VARCHAR(255) NOT NULL,
     role       VARCHAR(10)  NOT NULL,
@@ -47,7 +46,7 @@ CREATE TABLE manager
 
 CREATE TABLE product_category
 (
-    category_id   INT         NOT NULL AUTO_INCREMENT,
+    category_id   MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
     category_name VARCHAR(20) NOT NULL UNIQUE,
     category_type VARCHAR(10) NOT NULL,
 
@@ -56,50 +55,47 @@ CREATE TABLE product_category
 
 CREATE TABLE additional_option
 (
-    option_id    INT         NOT NULL AUTO_INCREMENT,
-    option_name  VARCHAR(10) NOT NULL,
-    option_price INT         NOT NULL,
-    max_quantity INT         NOT NULL,
+    option_id    INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    option_name  VARCHAR(10) NOT NULL UNIQUE,
+    option_price SMALLINT UNSIGNED NOT NULL,
+    max_quantity TINYINT UNSIGNED NOT NULL,
 
     PRIMARY KEY (option_id)
 );
 
-CREATE TABLE product_option
-(
-    product_option_id BIGINT NOT NULL AUTO_INCREMENT,
-    product_id        BIGINT NOT NULL,
-    option_id         INT    NOT NULL,
-    quantity          INT    NOT NULL,
-
-    PRIMARY KEY (product_option_id),
-    FOREIGN KEY (option_id) REFERENCES additional_option (option_id)
-);
-
 CREATE TABLE product
 (
-    product_id   BIGINT       NOT NULL AUTO_INCREMENT,
-    product_name VARCHAR(20)  NOT NULL,
-    category_id  INT          NOT NULL,
-    price        INT          NOT NULL,
-    option_id    BIGINT       NOT NULL,
+    product_id   INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    product_name VARCHAR(20)  NOT NULL UNIQUE,
+    category_id  MEDIUMINT UNSIGNED NOT NULL,
+    price        MEDIUMINT UNSIGNED NOT NULL,
     description  VARCHAR(255) NOT NULL,
     image        VARCHAR(255) NOT NULL,
-    is_active    VARCHAR(1)   NOT NULL,
+    is_active    BOOLEAN      NOT NULL,
     created_at   DATE,
 
     PRIMARY KEY (product_id),
-    FOREIGN KEY (category_id) REFERENCES product_category (category_id),
-    FOREIGN KEY (product_id) REFERENCES product_option (product_option_id)
+    FOREIGN KEY (category_id) REFERENCES product_category (category_id)
+);
+
+CREATE TABLE product_option
+(
+    product_id INT UNSIGNED NOT NULL,
+    option_id  INT UNSIGNED NOT NULL,
+    quantity   TINYINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (product_id, option_id),
+    FOREIGN KEY (option_id) REFERENCES additional_option (option_id),
+    FOREIGN KEY (product_id) REFERENCES product (product_id)
 );
 
 CREATE TABLE office_stock
 (
-    stock_id    BIGINT NOT NULL AUTO_INCREMENT,
-    office_id   INT    NOT NULL,
-    product_id  BIGINT NOT NULL,
-    stock_value INT    NOT NULL,
+    office_id   MEDIUMINT UNSIGNED NOT NULL,
+    product_id  INT UNSIGNED NOT NULL,
+    stock_value SMALLINT UNSIGNED NOT NULL,
 
-    PRIMARY KEY (stock_id),
+    PRIMARY KEY (office_id, product_id),
     FOREIGN KEY (office_id) REFERENCES office (office_id),
     FOREIGN KEY (product_id) REFERENCES product (product_id)
 );
@@ -108,11 +104,11 @@ CREATE TABLE my_menu
 (
     my_menu_id   BIGINT      NOT NULL AUTO_INCREMENT,
     my_menu_name VARCHAR(10) NOT NULL,
-    product_id   BIGINT      NOT NULL,
+    product_id   INT UNSIGNED NOT NULL,
     member_id    BIGINT      NOT NULL,
     option_info  JSON        NOT NULL,
 
     PRIMARY KEY (my_menu_id),
-    FOREIGN KEY (member_id) REFERENCES members (member_id),
+    FOREIGN KEY (member_id) REFERENCES member (member_id),
     FOREIGN KEY (product_id) REFERENCES product (product_id)
 );

--- a/src/test/resources/clean.sql
+++ b/src/test/resources/clean.sql
@@ -1,10 +1,9 @@
 DELETE FROM my_menu;
 DELETE FROM office_stock;
-DELETE FROM product;
 DELETE FROM product_option;
+DELETE FROM product;
 DELETE FROM additional_option;
 DELETE FROM product_category;
-DELETE FROM product_type;
 DELETE FROM manager;
 DELETE FROM office;
-DELETE FROM members;
+DELETE FROM member;


### PR DESCRIPTION
#### **우선 DB 스키마 관련 변경된 부분은 다음과 같습니다.**
* members 테이블을 단수형 member로 변경
* product 테이블과 additional_option의 다대다 관계를 매핑하는 테이블인 product_option 테이블의 기본키를 surrogate key에서 natural key로 변경
* 마찬가지로 매장별 제품별 재고를 나타내는 office_stock 테이블의 기본키를 natural key 로 변경 
* proudct_option 테이블에서 기존에 product_id를 외래키로 설정 안해줬던 부분을 설정해주고 product 테이블에 잘못 설정되어있던 외래키 삭제
* BIGINT를 제외하고 양의 정수만 존재하는 필드에 대해 UNSIGNED 적용과 그에 따른 자바 클래스 필드 변경
 (UNSINGED BIGINT 는 primitive type이 없고 성능이 좋지 않은 BigInteger를 써야 하고 BIGINT의 양수 범위로도 충분하다는 판단)
* 그 외 정수형 범위 적당하게 변경
* additional_option 테이블과 product 테이블의 name 에 UNIQUE 제약조건 추가
* product 테이블 is_active 필드를 VARCHAR(1) 에서 BOOLEAN(MySQL 내부적으로는 TINYINT(1)과 동일) 으로 변경

#### **추가적으로**
* 옵션이 존재 하지 않더라도 예외를 던지지 않고 빈 리스트 반환
* UNIQUE 조건을 걸어준 부분에 대해 검사하지 않고 저장 시도 후 중복시 스프링이 던지는 DuplicateKeyException 을 다시 전환해서 반환
* Command 객체에 유효성 검사 빠져있거나 스키마 변경에 따른 추가 