### PR TITLE
[#62] 현재 위치 주변의 매장을 검색하는 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     // https://github.com/aws/aws-sdk-java/blob/6a086cfd3e26f74592cf3a7cb96f43e51654a926/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java#L67
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+    // WGS-84 기반 지리 공간 계산 라이브러리 의존성 추가
+    implementation 'org.locationtech.spatial4j:spatial4j:0.8'
+
     // MySQL 의존성 추가
     runtimeOnly 'mysql:mysql-connector-java'
 

--- a/src/main/java/dabang/star/cafe/api/OfficeSearchApi.java
+++ b/src/main/java/dabang/star/cafe/api/OfficeSearchApi.java
@@ -1,0 +1,33 @@
+package dabang.star.cafe.api;
+
+import dabang.star.cafe.application.OfficeQueryService;
+import dabang.star.cafe.application.command.OfficeSearchCommand;
+import dabang.star.cafe.application.data.OfficeSearchData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/offices")
+public class OfficeSearchApi {
+
+    private final OfficeQueryService officeQueryService;
+
+    /**
+     * 현재 위치를 받아 주변 매장을 검색하는 API
+     *
+     * @param officeSearchCommand (curLatitude, curLongitude)
+     * @return 검색된 인근의 매장 정보 반환
+     */
+    @PostMapping("/search")
+    public List<OfficeSearchData> nearByOffice(@Valid @RequestBody OfficeSearchCommand officeSearchCommand) {
+        return officeQueryService.searchOfficeByDistanceFromCurrentLocation(officeSearchCommand);
+    }
+
+}

--- a/src/main/java/dabang/star/cafe/application/OfficeQueryService.java
+++ b/src/main/java/dabang/star/cafe/application/OfficeQueryService.java
@@ -1,0 +1,43 @@
+package dabang.star.cafe.application;
+
+import dabang.star.cafe.application.command.OfficeSearchCommand;
+import dabang.star.cafe.application.data.OfficeSearchData;
+import dabang.star.cafe.domain.office.Location;
+import dabang.star.cafe.domain.office.OfficeRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceCalculator;
+import org.locationtech.spatial4j.distance.GeodesicSphereDistCalc;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static org.locationtech.spatial4j.distance.DistanceUtils.KM_TO_DEG;
+
+@Service
+@RequiredArgsConstructor
+public class OfficeQueryService {
+
+    private final OfficeRepository officeRepository;
+
+    private final double NEAR_RADIUS = 3;
+
+    public List<OfficeSearchData> searchOfficeByDistanceFromCurrentLocation(OfficeSearchCommand officeSearchCommand) {
+        double curX = officeSearchCommand.getCurLongitude().doubleValue();
+        double curY = officeSearchCommand.getCurLatitude().doubleValue();
+        Point curPoint = new PointImpl(curX, curY, SpatialContext.GEO);
+
+        // 왼쪽 아래(서쪽 경도, 남쪽 위도)와 오른쪽 위(동쪽 경도, 북쪽 위도)를 활용.
+        DistanceCalculator vincenty = new GeodesicSphereDistCalc.Vincenty();
+        Point northPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 0.0, SpatialContext.GEO, null);
+        Point eastPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 90.0, SpatialContext.GEO, null);
+        Point southPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 180.0, SpatialContext.GEO, null);
+        Point westPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 270.0, SpatialContext.GEO, null);
+
+        return officeRepository.findNearByLineString(
+                new Location(curX, curY), westPoint.getX(), southPoint.getY(), eastPoint.getX(), northPoint.getY()
+        );
+    }
+}

--- a/src/main/java/dabang/star/cafe/application/OfficeQueryService.java
+++ b/src/main/java/dabang/star/cafe/application/OfficeQueryService.java
@@ -22,22 +22,9 @@ public class OfficeQueryService {
 
     private final OfficeRepository officeRepository;
 
-    private final double NEAR_RADIUS = 3;
-
     public List<OfficeSearchData> searchOfficeByDistanceFromCurrentLocation(OfficeSearchCommand officeSearchCommand) {
-        double curX = officeSearchCommand.getCurLongitude().doubleValue();
-        double curY = officeSearchCommand.getCurLatitude().doubleValue();
-        Point curPoint = new PointImpl(curX, curY, SpatialContext.GEO);
 
-        // 왼쪽 아래(서쪽 경도, 남쪽 위도)와 오른쪽 위(동쪽 경도, 북쪽 위도)를 활용.
-        DistanceCalculator vincenty = new GeodesicSphereDistCalc.Vincenty();
-        Point northPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 0.0, SpatialContext.GEO, null);
-        Point eastPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 90.0, SpatialContext.GEO, null);
-        Point southPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 180.0, SpatialContext.GEO, null);
-        Point westPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 270.0, SpatialContext.GEO, null);
-
-        return officeRepository.findNearByLineString(
-                new Location(curX, curY), westPoint.getX(), southPoint.getY(), eastPoint.getX(), northPoint.getY()
-        );
+        Location curLocation = officeSearchCommand.toLocation();
+        return officeRepository.findNearByLineString(curLocation, curLocation.nearLineString());
     }
 }

--- a/src/main/java/dabang/star/cafe/application/command/OfficeCreateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OfficeCreateCommand.java
@@ -1,5 +1,6 @@
 package dabang.star.cafe.application.command;
 
+import dabang.star.cafe.domain.office.Location;
 import dabang.star.cafe.domain.office.Office;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,9 +33,8 @@ public class OfficeCreateCommand {
         return Office.builder()
                 .name(name)
                 .address(address)
-                .latitude(latitude)
-                .longitude(longitude)
+                .location(new Location(longitude, latitude))
                 .build();
     }
-    
+
 }

--- a/src/main/java/dabang/star/cafe/application/command/OfficeSearchCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OfficeSearchCommand.java
@@ -1,5 +1,6 @@
 package dabang.star.cafe.application.command;
 
+import dabang.star.cafe.domain.office.Location;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,4 +19,8 @@ public class OfficeSearchCommand {
 
     @NotNull(message = "blank current longitude")
     private BigDecimal curLongitude;
+
+    public Location toLocation() {
+        return new Location(curLongitude.doubleValue(), curLatitude.doubleValue());
+    }
 }

--- a/src/main/java/dabang/star/cafe/application/command/OfficeSearchCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OfficeSearchCommand.java
@@ -1,0 +1,21 @@
+package dabang.star.cafe.application.command;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class OfficeSearchCommand {
+
+    @NotNull(message = "blank current latitude.")
+    private BigDecimal curLatitude;
+
+    @NotNull(message = "blank current longitude")
+    private BigDecimal curLongitude;
+}

--- a/src/main/java/dabang/star/cafe/application/command/OfficeUpdateCommand.java
+++ b/src/main/java/dabang/star/cafe/application/command/OfficeUpdateCommand.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -26,20 +25,12 @@ public class OfficeUpdateCommand {
     @NotBlank(message = "blank office address")
     private String address;
 
-    @NotNull(message = "blank office latitude")
-    private BigDecimal latitude;
-
-    @NotNull(message = "blank office latitude")
-    private BigDecimal longitude;
-
     public Office toOffice() {
 
         return Office.builder()
                 .id(id)
                 .name(name)
                 .address(address)
-                .latitude(latitude)
-                .longitude(longitude)
                 .build();
     }
 }

--- a/src/main/java/dabang/star/cafe/application/data/OfficeSearchData.java
+++ b/src/main/java/dabang/star/cafe/application/data/OfficeSearchData.java
@@ -1,0 +1,16 @@
+package dabang.star.cafe.application.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OfficeSearchData {
+
+    private String name;
+
+    private String address;
+
+    private String distance;
+
+}

--- a/src/main/java/dabang/star/cafe/application/data/OfficeSearchData.java
+++ b/src/main/java/dabang/star/cafe/application/data/OfficeSearchData.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class OfficeSearchData {
 
+    private Integer id;
+
     private String name;
 
     private String address;

--- a/src/main/java/dabang/star/cafe/domain/office/Location.java
+++ b/src/main/java/dabang/star/cafe/domain/office/Location.java
@@ -1,0 +1,42 @@
+package dabang.star.cafe.domain.office;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.StringTokenizer;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Location {
+
+    private String longitude;
+
+    private String latitude;
+
+    public Location(BigDecimal lng, BigDecimal lat) {
+        longitude = lng.toString();
+        latitude = lat.toString();
+    }
+
+    public Location(double lng, double lat) {
+        longitude = String.valueOf(lng);
+        latitude = String.valueOf(lat);
+    }
+
+    public static Location parseFrom(String pointString) {
+        StringTokenizer stringTokenizer = new StringTokenizer(pointString.toLowerCase()
+                .replaceAll("point\\(", "")
+                .replaceAll("\\)", "")
+        );
+
+        return new Location(stringTokenizer.nextToken(), stringTokenizer.nextToken());
+    }
+
+    @Override
+    public String toString() {
+        return "point(" + longitude + " " + latitude + ")";
+    }
+}

--- a/src/main/java/dabang/star/cafe/domain/office/Location.java
+++ b/src/main/java/dabang/star/cafe/domain/office/Location.java
@@ -3,9 +3,16 @@ package dabang.star.cafe.domain.office;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceCalculator;
+import org.locationtech.spatial4j.distance.GeodesicSphereDistCalc;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
 
 import java.math.BigDecimal;
 import java.util.StringTokenizer;
+
+import static org.locationtech.spatial4j.distance.DistanceUtils.KM_TO_DEG;
 
 @Getter
 @NoArgsConstructor
@@ -15,6 +22,8 @@ public class Location {
     private String longitude;
 
     private String latitude;
+
+    private final double NEAR_RADIUS = 3;
 
     public Location(BigDecimal lng, BigDecimal lat) {
         longitude = lng.toString();
@@ -38,5 +47,18 @@ public class Location {
     @Override
     public String toString() {
         return "point(" + longitude + " " + latitude + ")";
+    }
+
+    public String nearLineString() {
+        Point curPoint = new PointImpl(Double.parseDouble(longitude), Double.parseDouble(latitude), SpatialContext.GEO);
+
+        // 왼쪽 아래(서쪽 경도, 남쪽 위도)와 오른쪽 위(동쪽 경도, 북쪽 위도)를 활용.
+        DistanceCalculator vincenty = new GeodesicSphereDistCalc.Vincenty();
+        Point northPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 0.0, SpatialContext.GEO, null);
+        Point eastPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 90.0, SpatialContext.GEO, null);
+        Point southPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 180.0, SpatialContext.GEO, null);
+        Point westPoint = vincenty.pointOnBearing(curPoint, KM_TO_DEG * NEAR_RADIUS, 270.0, SpatialContext.GEO, null);
+
+        return "LINESTRING(" + westPoint.getX() + " " + southPoint.getY() + ", " + eastPoint.getX() + " " + northPoint.getY() + ")";
     }
 }

--- a/src/main/java/dabang/star/cafe/domain/office/Location.java
+++ b/src/main/java/dabang/star/cafe/domain/office/Location.java
@@ -19,20 +19,20 @@ import static org.locationtech.spatial4j.distance.DistanceUtils.KM_TO_DEG;
 @AllArgsConstructor
 public class Location {
 
-    private String longitude;
+    private double longitude;
 
-    private String latitude;
+    private double latitude;
 
     private final double NEAR_RADIUS = 3;
 
     public Location(BigDecimal lng, BigDecimal lat) {
-        longitude = lng.toString();
-        latitude = lat.toString();
+        longitude = lng.doubleValue();
+        latitude = lat.doubleValue();
     }
 
-    public Location(double lng, double lat) {
-        longitude = String.valueOf(lng);
-        latitude = String.valueOf(lat);
+    public Location(String lng, String lat) {
+        longitude = Double.parseDouble(lng);
+        latitude = Double.parseDouble(lat);
     }
 
     public static Location parseFrom(String pointString) {
@@ -50,7 +50,7 @@ public class Location {
     }
 
     public String nearLineString() {
-        Point curPoint = new PointImpl(Double.parseDouble(longitude), Double.parseDouble(latitude), SpatialContext.GEO);
+        Point curPoint = new PointImpl(longitude, latitude, SpatialContext.GEO);
 
         // 왼쪽 아래(서쪽 경도, 남쪽 위도)와 오른쪽 위(동쪽 경도, 북쪽 위도)를 활용.
         DistanceCalculator vincenty = new GeodesicSphereDistCalc.Vincenty();

--- a/src/main/java/dabang/star/cafe/domain/office/Office.java
+++ b/src/main/java/dabang/star/cafe/domain/office/Office.java
@@ -17,7 +17,5 @@ public class Office {
 
     private String address;
 
-    private BigDecimal latitude;
-
-    private BigDecimal longitude;
+    private Location location;
 }

--- a/src/main/java/dabang/star/cafe/domain/office/OfficeRepository.java
+++ b/src/main/java/dabang/star/cafe/domain/office/OfficeRepository.java
@@ -20,5 +20,5 @@ public interface OfficeRepository {
 
     Page<OfficeData> findAll(Pagination pagination);
 
-    List<OfficeSearchData> findNearByLineString(Location curLoc, double minX, double minY, double maxX, double maxY);
+    List<OfficeSearchData> findNearByLineString(Location curLoc, String lineString);
 }

--- a/src/main/java/dabang/star/cafe/domain/office/OfficeRepository.java
+++ b/src/main/java/dabang/star/cafe/domain/office/OfficeRepository.java
@@ -1,9 +1,11 @@
 package dabang.star.cafe.domain.office;
 
 import dabang.star.cafe.application.data.OfficeData;
+import dabang.star.cafe.application.data.OfficeSearchData;
 import dabang.star.cafe.utils.page.Page;
 import dabang.star.cafe.utils.page.Pagination;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OfficeRepository {
@@ -17,4 +19,6 @@ public interface OfficeRepository {
     Optional<OfficeData> findByName(String officeName);
 
     Page<OfficeData> findAll(Pagination pagination);
+
+    List<OfficeSearchData> findNearByLineString(Location curLoc, double minX, double minY, double maxX, double maxY);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/mapper/OfficeMapper.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/mapper/OfficeMapper.java
@@ -27,5 +27,5 @@ public interface OfficeMapper {
 
     List<OfficeData> getByPagination(int limit, int offset);
 
-    List<OfficeSearchData> getByLineString(Location curLoc, double minX, double minY, double maxX, double maxY);
+    List<OfficeSearchData> getByLineString(Location curLoc, String lineString);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/mapper/OfficeMapper.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/mapper/OfficeMapper.java
@@ -1,5 +1,7 @@
 package dabang.star.cafe.infrastructure.mapper;
 
+import dabang.star.cafe.application.data.OfficeSearchData;
+import dabang.star.cafe.domain.office.Location;
 import dabang.star.cafe.domain.office.Office;
 import dabang.star.cafe.application.data.OfficeData;
 import org.apache.ibatis.annotations.Mapper;
@@ -24,4 +26,6 @@ public interface OfficeMapper {
     int getCountAll();
 
     List<OfficeData> getByPagination(int limit, int offset);
+
+    List<OfficeSearchData> getByLineString(Location curLoc, double minX, double minY, double maxX, double maxY);
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/mybatis/LocationHandler.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/mybatis/LocationHandler.java
@@ -1,0 +1,37 @@
+package dabang.star.cafe.infrastructure.mybatis;
+
+import dabang.star.cafe.domain.office.Location;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes({Location.class})
+@MappedJdbcTypes(JdbcType.VARCHAR)
+public class LocationHandler implements TypeHandler<Location> {
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, Location parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.toString());
+    }
+
+    @Override
+    public Location getResult(ResultSet rs, String columnName) throws SQLException {
+        return Location.parseFrom(rs.getString(columnName));
+    }
+
+    @Override
+    public Location getResult(ResultSet rs, int columnIndex) throws SQLException {
+        return Location.parseFrom(rs.getString(columnIndex));
+    }
+
+    @Override
+    public Location getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return Location.parseFrom(cs.getResultSet().getString(columnIndex));
+    }
+}

--- a/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOfficeRepository.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOfficeRepository.java
@@ -57,7 +57,7 @@ public class MybatisOfficeRepository implements OfficeRepository {
     }
 
     @Override
-    public List<OfficeSearchData> findNearByLineString(Location curLoc, double minX, double minY, double maxX, double maxY) {
-        return officeMapper.getByLineString(curLoc, minX, minY, maxX, maxY);
+    public List<OfficeSearchData> findNearByLineString(Location curLoc, String lineString) {
+        return officeMapper.getByLineString(curLoc, lineString);
     }
 }

--- a/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOfficeRepository.java
+++ b/src/main/java/dabang/star/cafe/infrastructure/repository/MybatisOfficeRepository.java
@@ -1,6 +1,8 @@
 package dabang.star.cafe.infrastructure.repository;
 
 import dabang.star.cafe.application.data.OfficeData;
+import dabang.star.cafe.application.data.OfficeSearchData;
+import dabang.star.cafe.domain.office.Location;
 import dabang.star.cafe.domain.office.Office;
 import dabang.star.cafe.domain.office.OfficeRepository;
 import dabang.star.cafe.infrastructure.mapper.OfficeMapper;
@@ -52,5 +54,10 @@ public class MybatisOfficeRepository implements OfficeRepository {
         List<OfficeData> officeDataList = officeMapper.getByPagination(size, pagination.getOffset());
 
         return Page.from(officeDataList, totalCount, size, pagination.getPage());
+    }
+
+    @Override
+    public List<OfficeSearchData> findNearByLineString(Location curLoc, double minX, double minY, double maxX, double maxY) {
+        return officeMapper.getByLineString(curLoc, minX, minY, maxX, maxY);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/star_dabang?serverTimezone=UTC&characterEncoding=utf8&useSSL=false&allowMultiQueries=true
-    #    url: jdbc:mysql://172.17.0.2:3306/yslocaldb?allowMultiQueries=true
+#    url: jdbc:mysql://172.17.0.2:3306/yslocaldb?characterEncoding=utf8&allowMultiQueries=true
     username: root
     password: root
     initialization-mode: always

--- a/src/main/resources/data-dev.sql
+++ b/src/main/resources/data-dev.sql
@@ -9,10 +9,10 @@ VALUES ('test4@naver.com', SHA2('12345', 256), '테스트', '01012345678', '2020
 INSERT INTO member(email, passwd, nickName, phone, birth)
 VALUES ('test5@naver.com', SHA2('12345', 256), '테스트', '01012345678', '20201010');
 
-INSERT INTO office(office_name, address, latitude, longitude)
-VALUES ('본사', '제주도 제주시 돌하르방 12-34', '37.3737372323', '127.232323323');
-INSERT INTO office(office_name, address, latitude, longitude)
-VALUES ('신논현점', '서울시 서초구 강남대로 465', '37.5038887717', '127.024111957');
+INSERT INTO office(office_name, address, location)
+VALUES ('본사', '제주도 제주시 돌하르방 12-34', GeomFromText('POINT(127.232323323 37.3737372323)'));
+INSERT INTO office(office_name, address, location)
+VALUES ('신논현점', '서울시 서초구 강남대로 465', GeomFromText('POINT(127.024111957 37.5038887717)'));
 
 INSERT INTO manager(office_id, name, passwd, role)
 VALUES (1, 'root', SHA2('root', 256), 'ADMIN');

--- a/src/main/resources/mybatis-mapper/OfficeMapper.xml
+++ b/src/main/resources/mybatis-mapper/OfficeMapper.xml
@@ -62,7 +62,8 @@
     </delete>
 
     <select id="getByLineString" resultType="OfficeSearchData">
-        SELECT o.office_name                                                                                                              AS name,
+        SELECT o.office_id                                                                                                                AS id,
+               o.office_name                                                                                                              AS name,
                o.address                                                                                                                  AS address,
                ST_Distance_Sphere(o.location, ST_GeomFromText(
                        #{curLoc,jdbcType=VARCHAR,javaType=Location,typeHandler=dabang.star.cafe.infrastructure.mybatis.LocationHandler})) AS distance

--- a/src/main/resources/mybatis-mapper/OfficeMapper.xml
+++ b/src/main/resources/mybatis-mapper/OfficeMapper.xml
@@ -2,24 +2,32 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="dabang.star.cafe.infrastructure.mapper.OfficeMapper">
 
-    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO office (office_name, address, latitude, longitude)
-        VALUES (#{name}, #{address}, #{latitude}, #{longitude})
+    <resultMap id="OfficeResultMap" type="dabang.star.cafe.domain.office.Office">
+        <id column="office_id" property="id" jdbcType="INTEGER"/>
+        <id column="office_name" property="name" jdbcType="VARCHAR"/>
+        <id column="address" property="address" jdbcType="VARCHAR"/>
+        <id column="location" property="location" jdbcType="VARCHAR"
+            typeHandler="dabang.star.cafe.infrastructure.mybatis.LocationHandler"/>
+    </resultMap>
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id" parameterType="dabang.star.cafe.domain.office.Office">
+        INSERT INTO office (office_name, address, location)
+        VALUES (#{name,jdbcType=VARCHAR}, #{address,jdbcType=VARCHAR},
+                ST_GeomFromText(#{location,jdbcType=VARCHAR,javaType=Location,
+                        typeHandler=dabang.star.cafe.infrastructure.mybatis.LocationHandler}))
     </insert>
 
-    <update id="update" keyProperty="id">
+    <update id="update" keyProperty="id" parameterType="dabang.star.cafe.domain.office.Office">
         UPDATE office
         <set>
             <if test="name != null">office_name=#{name},</if>
             <if test="address != null">address=#{address},</if>
-            <if test="latitude != null">latitude=#{latitude},</if>
-            <if test="longitude != null">longitude=#{longitude},</if>
         </set>
         WHERE office_id=#{id}
     </update>
 
-    <select id="getById" resultType="Office" parameterType="map">
-        SELECT o.office_id, o.office_name, o.address, o.latitude, o.longitude
+    <select id="getById" resultMap="OfficeResultMap">
+        SELECT o.office_id, o.office_name, o.address, ST_AsText(location) AS location
         FROM office o
         WHERE o.office_id = #{id}
     </select>

--- a/src/main/resources/mybatis-mapper/OfficeMapper.xml
+++ b/src/main/resources/mybatis-mapper/OfficeMapper.xml
@@ -67,8 +67,7 @@
                ST_Distance_Sphere(o.location, ST_GeomFromText(
                        #{curLoc,jdbcType=VARCHAR,javaType=Location,typeHandler=dabang.star.cafe.infrastructure.mybatis.LocationHandler})) AS distance
         FROM office o
-        WHERE ST_Within(o.location, ST_Envelope(ST_GeomFromText(
-                CONCAT('LINESTRING(', #{minX}, ' ', #{minY}, ', ', #{maxX}, ' ', #{maxY}, ')'))))
+        WHERE ST_Within(o.location, ST_Envelope(ST_GeomFromText(#{lineString,jdbcType=VARCHAR})))
         ORDER BY distance;
     </select>
 

--- a/src/main/resources/mybatis-mapper/OfficeMapper.xml
+++ b/src/main/resources/mybatis-mapper/OfficeMapper.xml
@@ -61,4 +61,15 @@
         WHERE office_id = #{id}
     </delete>
 
+    <select id="getByLineString" resultType="OfficeSearchData">
+        SELECT o.office_name                                                                                                              AS name,
+               o.address                                                                                                                  AS address,
+               ST_Distance_Sphere(o.location, ST_GeomFromText(
+                       #{curLoc,jdbcType=VARCHAR,javaType=Location,typeHandler=dabang.star.cafe.infrastructure.mybatis.LocationHandler})) AS distance
+        FROM office o
+        WHERE ST_Within(o.location, ST_Envelope(ST_GeomFromText(
+                CONCAT('LINESTRING(', #{minX}, ' ', #{minY}, ', ', #{maxX}, ' ', #{maxY}, ')'))))
+        ORDER BY distance;
+    </select>
+
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -28,10 +28,10 @@ CREATE TABLE office
     office_id   MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
     office_name VARCHAR(50)        NOT NULL,
     address     VARCHAR(255)       NOT NULL,
-    latitude    DECIMAL(16, 14)    NOT NULL,
-    longitude   DECIMAL(17, 14)    NOT NULL,
+    location    POINT              NOT NULL,
 
-    PRIMARY KEY (office_id)
+    PRIMARY KEY (office_id),
+    SPATIAL INDEX OFFICE_LOC (location)
 );
 
 CREATE TABLE manager


### PR DESCRIPTION
**우선은 DB 스키마를 변경하였습니다.** 
기존의 위도 경도 각각 따로 저장하던 방식에서 MySQL의 Point 타입을 활용하였고 Spatial 인덱스를 걸어줬습니다. R-Tree 인덱스인 Spatial 인덱스를 활용하여 위치 기반 검색시 풀스캔을 하지 않고 빠르게 검색하기 위함입니다.
변경된 필드는 Location 이라는 클래스를 만들어서 Mybatis TypeHandler를 추가하여 처리하였습니다.

**풀스캔하지 않는 쿼리 작성**
쿼리의 WHERE절에서 ST_LINESTRING의 ST_ENVELOPE 를 활용하여 풀스캔하지 않도록 하였습니다. 
현재 위치의 동서남북 지점을 구하기 위해 java geo library 등으로 검색해보고 이클립스 프로젝트인 Spatial4J 라는 라이브러리를 활용하였습니다. 
로컬에서 데이터를 2만개 넣어보고 EXPLAIN을 통해 테스트해본결과 일부만 스캔하는 것을 확인하였습니다.