### PR TITLE
[#70] MySQL Master-Slave 복제 구성

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,3 +66,43 @@ cloud:
 mybatis:
   mapper-locations: classpath:mybatis-mapper/**/*.xml
   type-aliases-package: dabang.star.cafe.domain, dabang.star.cafe.application.data
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://10.174.0.10:3306/stardabangdb?characterEncoding=utf8
+    username: appuser
+    password: apppass
+    initialization-mode: never
+
+  session:
+    store-type: redis
+    redis:
+      namespace: star_dabang:session
+
+  cache:
+    type: redis
+
+  cloud:
+    gcp:
+      credentials:
+        location: classpath:gcp-credentials.json
+      storage:
+        bucket: star-dabang
+
+  redis:
+    host: localhost
+    #    host: 172.18.0.2
+    port: 6379
+
+mybatis:
+  mapper-locations: classpath:mybatis-mapper/**/*.xml
+  type-aliases-package: dabang.star.cafe.domain, dabang.star.cafe.application.data
+
+logging:
+  config: classpath:log4j2.yaml


### PR DESCRIPTION
### _배포 환경을 위한 prod profile 추가하였고 이 프로필에서는 복제 구성된 mysql을 바라봅니다._


### 사용기술

> * [openark/orchestrator](https://github.com/openark/orchestrator)
> * [proxysql 2.0.17](proxysql.com)

참고문서:
[MySQL Automated recovery with Orchestrator](https://velog.io/@hansung/MySQL-with-Orchestrator-Automated-recovery)
[MYSQL을 효율적으로 확장하기 위한 PROXYSQL](https://hakurei.tistory.com/306)
[Compute Engine 기반 MySQL 클러스터의 고가용성을 위한 아키텍처](https://cloud.google.com/architecture/architectures-high-availability-mysql-clusters-compute-engine?hl=ko)

  #

### 아키텍처(사진은 오라클 리눅스인데 GCP CentOS8 에서 다시 구축했습니다)

![](https://i.ibb.co/2Ss1Km9/mysql-replication2.png)

  #

### 설명

스프링에서는 멀티 데이터소스 연결을 위해 AbstractRoutingDataSource 라는 추상 클래스를 제공합니다.
JDBC 커넥션에는 setReadOnly(true | false)라는 메소드가 존재하기 때문에 스프링의 Transactional 어노테이션의 readOnly 옵션을 통해 setReadOnly 를 호출하게 되고 이를 구분해 분배를 쉽게 할 수 있습니다. (또는 AOP를 활용합니다) 

star-dabang 프로젝트에서 특정 이벤트 시간에 트래픽이 쏟아진다고 가정할 때 장애 발생시 최대한 빠른 시간에 복구하는 것이 매출에 중요하다고 판단했고 Auto Fail Over를 지원하는 Orchestrator를 통하여 구성하였습니다. 
자동으로 Slave가 Master로 승격된다면 스프링의 AbstractRoutingDataSource로는 결국 분배가 힘들어질테고 WAS또한 다시 재부팅 해야 하는 문제가 있었습니다. 이를 해결하기 위해 중간에 ProxySQL을 사용하였습니다. 또한 ProxySQL은 들어오는 쿼리를 바탕으로 Query Rule을 등록하여 읽기 쿼리는 Slave로 보낼 수 있어서 매우 적합했습니다.

인스턴스 별로 따로 따로 서버를 구성할 수도 있지만 Auto-Fail-Over 되고 장애난 DB 인스턴스를 직접 복구해서 다시 붙였을 때 IP가 변경될수도 있어서(이는 도커 컨테이너 환경도 마찬가지), 이를 해결하기 위해 다른 솔루션을 도입할 수도 있지만, 도커의 브리지 네트워크를 구성하는 것이 제일 간단한 방식이었습니다. 추후 성능테스트 시에 DB 서버의 리소스가 부족하여 확장성이 필요하다면 Swarm Mode를 통해 인스턴스를 더 띄우고 클러스터링 형태로 구성하는 방식을 생각중입니다. 

  #

#### 도커 ProxySQL, Orchestrator, Master DB 1개, Slave DB 2개 구성

(데이터볼륨 공유를 위한 디렉토리, cnf파일 생성과 기본적인 도커설치 절차는 생략) 빠른 구성을 위해 도커 컴포즈, 쉘 스크립트, Python 을 활용하여 ~/ 위치에 아래 파일을 생성하고 다음을 실행하였습니다.
>```shell
>docker-compose up -d
>python3 auto-failover.py
>sh post_script.sh
>```


**docker-compose.yml**
```yml
version: "3.8"
services:
  db001:
    image: mysql:5.7.34
    container_name: db001
    hostname: db001
    ports:
      - "3306:3306"
    environment:
      MYSQL_ROOT_PASSWORD: 'root'
    volumes:
      - /db/db001/data:/var/lib/mysql
      - /db/db001/log:/var/log/mysql
      - /db/db001/conf:/etc/mysql/conf.d
    networks:
      - mybridge
  db002:
    image: mysql:5.7.34
    container_name: db002
    hostname: db002
    ports:
      - "3307:3306"
    environment:
      MYSQL_ROOT_PASSWORD: 'root'
    volumes:
      - /db/db002/data:/var/lib/mysql
      - /db/db002/log:/var/log/mysql
      - /db/db002/conf:/etc/mysql/conf.d
    networks:
      - mybridge
  db003:
    image: mysql:5.7.34
    container_name: db003
    hostname: db003
    ports:
      - "3308:3306"
    environment:
      MYSQL_ROOT_PASSWORD: 'root'
    volumes:
      - /db/db003/data:/var/lib/mysql
      - /db/db003/log:/var/log/mysql
      - /db/db003/conf:/etc/mysql/conf.d
    networks:
      - mybridge
  orchestrator:
    image: openarkcode/orchestrator:latest
    container_name: orchestrator
    hostname: orchestrator
    ports:
      - "3000:3000"
    networks:
      - mybridge
  proxysql:
    image: proxysql/proxysql
    container_name: proxysql
    hostname: proxysql
    ports:
      - "16032:6032"
      - "16033:6033"
    volumes:
      - /db/proxysql/data:/var/lib/proxysql
      - /db/proxysql/conf/proxysql.cnf:/etc/proxysql.cnf
    networks:
      - mybridge

networks:
  mybridge:
    external: true
```

**post_script.sh**
```shell
MASTER_NODE='db001'
SLAVE01_NODE='db002'
SLAVE02_NODE='db003'

EXEC_MASTER="docker exec ${MASTER_NODE} mysql -uroot -proot -N -e "
EXEC_SLAVE01="docker exec ${SLAVE01_NODE} mysql -uroot -proot -e "
EXEC_SLAVE02="docker exec ${SLAVE02_NODE} mysql -uroot -proot -e "

## For Replication (GTID, Not Binary log)
${EXEC_MASTER} "CREATE USER 'repl'@'%' IDENTIFIED BY 'repl'" 2>&1 | grep -v "Using a password"
${EXEC_MASTER} "GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%'" 2>&1 | grep -v "Using a password"

${EXEC_SLAVE01} "reset master" 2>&1 | grep -v "Using a password"
${EXEC_SLAVE01} "CHANGE MASTER TO MASTER_HOST='${MASTER_NODE}', \
MASTER_USER='repl', MASTER_PASSWORD='repl', \
MASTER_AUTO_POSITION=1" 2>&1 | grep -v "Using a password"
${EXEC_SLAVE01} "START SLAVE" 2>&1 | grep -v "Using a password"

${EXEC_SLAVE02} "reset master" 2>&1 | grep -v "Using a password"
${EXEC_SLAVE02} "CHANGE MASTER TO MASTER_HOST='${MASTER_NODE}', \
MASTER_USER='repl', MASTER_PASSWORD='repl', \
MASTER_AUTO_POSITION=1" 2>&1 | grep -v "Using a password"
${EXEC_SLAVE02} "START SLAVE" 2>&1 | grep -v "Using a password"

## For Orchestrator
${EXEC_MASTER} "CREATE USER orc_client_user@'%' IDENTIFIED BY 'orc_client_password'" 2>&1 | grep -v "Using a password"
${EXEC_MASTER} "GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD ON *.* TO orc_client_user@'%'" 2>&1 | grep -v "Using a password"
${EXEC_MASTER} "GRANT SELECT ON mysql.slave_master_info TO orc_client_user@'%'" 2>&1 | grep -v "Using a password"

## For ProxySQL
${EXEC_MASTER} "CREATE DATABASE stardabangdb DEFAULT CHARACTER SET=utf8" 2>&1 | grep -v "Using a password"
${EXEC_MASTER} "CREATE USER appuser@'%' IDENTIFIED BY 'apppass'" 2>&1 | grep -v "Using a password"
${EXEC_MASTER} "GRANT SELECT, INSERT, UPDATE, DELETE ON stardabangdb.* TO appuser@'%'" 2>&1 | grep -v "Using a password"

EXEC_PROXY="mysql -h127.0.0.1 -P16032 -uradmin -pradmin -e "

## Grouping For Query Routing
${EXEC_PROXY} "INSERT INTO mysql_servers(hostgroup_id, hostname, port) VALUES (10, 'db001', 3306)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "INSERT INTO mysql_servers(hostgroup_id, hostname, port) VALUES (20, 'db001', 3306)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "INSERT INTO mysql_servers(hostgroup_id, hostname, port) VALUES (20, 'db002', 3306)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "INSERT INTO mysql_servers(hostgroup_id, hostname, port) VALUES (20, 'db003', 3306)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "INSERT INTO mysql_replication_hostgroups VALUES (10,20,'read_only','')" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "LOAD MYSQL SERVERS TO RUNTIME" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "SAVE MYSQL SERVERS TO DISK" 2>&1 | grep -v "Using a password"

## For App User(Spring Boot)
${EXEC_PROXY} "INSERT INTO mysql_users(username,password,default_hostgroup,transaction_persistent)
               VALUES ('appuser','apppass',10,0)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "LOAD MYSQL USERS TO RUNTIME" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "SAVE MYSQL USERS TO DISK" 2>&1 | grep -v "Using a password"

## Query Rule(1. SELECT FOR UPDATE => Master, 2. SELECT => SLAVE)
${EXEC_PROXY} "INSERT INTO mysql_query_rules(rule_id,active,match_pattern,destination_hostgroup)
               VALUES (1,1,'^SELECT.*FOR UPDATE$',10)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "INSERT INTO mysql_query_rules(rule_id,active,match_pattern,destination_hostgroup)
               VALUES (2,1,'^SELECT',20)" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "LOAD MYSQL QUERY RULES TO RUNTIME" 2>&1 | grep -v "Using a password"
${EXEC_PROXY} "SAVE MYSQL QUERY RULES TO DISK" 2>&1 | grep -v "Using a password"

```

**auto-failover.py**
```python
import subprocess
import json

# Copy
COPY_TO_HOST = "sudo docker cp orchestrator:/etc/orchestrator.conf.json ~/orchestrator.conf.json"
subprocess.call(COPY_TO_HOST, shell=True)

# Read
with open('~/orchestrator.conf.json', 'r') as jsonfile:
    json_data = json.load(jsonfile)

# Set Orchestrator for auto-fail-over(only change db001 <=> db002)
json_data["RecoverMasterClusterFilters"] = ["*"]
json_data["PromotionIgnoreHostnameFilters"] = ["db003"]

# temp authorize
TMP_AUTH = "sudo chmod 777 ~/orchestrator.conf.json"
subprocess.call(TMP_AUTH, shell=True)

# Write
with open('~/orchestrator.conf.json', 'w') as jsonfile:
    json.dump(json_data, jsonfile, indent=4)

# Copy
COPY_TO_CONTAINER = "sudo docker cp ~/orchestrator.conf.json orchestrator:/etc"
subprocess.call(COPY_TO_CONTAINER, shell=True)

# Remove
REMOVE_LOCAL = "sudo rm ~/orchestrator.conf.json"
subprocess.call(REMOVE_LOCAL, shell=True)

```

 #

### Orchestrator 웹 대시보드 접속 화면
![](https://i.ibb.co/HFDx4Ry/2021-05-02-07-12-04.png)